### PR TITLE
Create namespace for Argo

### DIFF
--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -31,5 +31,6 @@ local patches =
 
 // Define outputs below
 {
+  '00_namespace': kube.Namespace(params.namespace),
   '10_node_selector_patch': patches,
 }

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -11,8 +11,6 @@ default:: `openshift-networking`
 
 The namespace in which to deploy this component.
 
-NOTE: The component doesn't manage the namespace.
-
 
 == `defaultNodeSelector`
 

--- a/tests/golden/defaults/openshift4-networking/openshift4-networking/00_namespace.yaml
+++ b/tests/golden/defaults/openshift4-networking/openshift4-networking/00_namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations: {}
+  labels:
+    name: openshift-networking
+  name: openshift-networking


### PR DESCRIPTION
ArgoCD applies the namespace for all object that don't have one.
Even if they are cluster scoped.
The sync then fails if the ns does not exist.




## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
