### PR TITLE
Add logic to configure ServiceMonitors

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,6 +33,7 @@ jobs:
       matrix:
         instance:
           - defaults
+          - syn-monitoring
     defaults:
       run:
         working-directory: ${{ env.COMPONENT_NAME }}
@@ -48,6 +49,7 @@ jobs:
       matrix:
         instance:
           - defaults
+          - syn-monitoring
     defaults:
       run:
         working-directory: ${{ env.COMPONENT_NAME }}

--- a/.sync.yml
+++ b/.sync.yml
@@ -5,6 +5,7 @@
     key: instance
     entries:
       - defaults
+      - syn-monitoring
 
 docs/antora.yml:
   name: openshift4-networking

--- a/Makefile.vars.mk
+++ b/Makefile.vars.mk
@@ -36,4 +36,4 @@ COMPILE_CMD    ?= $(COMMODORE_CMD) component compile . $(commodore_args)
 JB_CMD         ?= $(DOCKER_CMD) $(DOCKER_ARGS) --entrypoint /usr/local/bin/jb docker.io/projectsyn/commodore:latest install
 
 instance ?= defaults
-test_instances = tests/defaults.yml
+test_instances = tests/defaults.yml tests/syn-monitoring.yml

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -9,7 +9,13 @@ parameters:
     monitoring:
       enabled: true
       instance: null
-      enableServiceMonitors: {}
+      enableServiceMonitors:
+        multus-admission-controller: true
+        multus-network: true
+        network-check-source: true
+        openshift-sdn: true
+        ovn-master: true
+        ovn-node: true
 
     patches:
       ip-reconciler:

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -6,6 +6,11 @@ parameters:
     defaultNodeSelector:
       node-role.kubernetes.io/infra: ''
 
+    monitoring:
+      enabled: true
+      instance: null
+      enableServiceMonitors: {}
+
     patches:
       ip-reconciler:
         target:

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -6,6 +6,7 @@ local resourceLocker = import 'lib/resource-locker.libjsonnet';
 // The hiera parameters for the component
 local params = inv.parameters.openshift4_networking;
 
+local metrics = import 'metrics.libsonnet';
 
 local patches =
   std.flattenArrays(
@@ -33,4 +34,4 @@ local patches =
 {
   '00_namespace': kube.Namespace(params.namespace),
   '10_node_selector_patch': patches,
-}
+} + metrics

--- a/component/metrics.libsonnet
+++ b/component/metrics.libsonnet
@@ -168,6 +168,18 @@ if syn_metrics then
       kube.Namespace(nsName),
       instance=promInstance
     ),
+    [if params.monitoring.enableServiceMonitors['network-check-source']
+    then '20_metrics_networkpolicy']: [
+      // openshift-multus and openshift-sdn don't have default
+      // networkpolicies, and openshift-ovn-kubernetes metrics are exposed on
+      // hostport. TBD: do we need additional networkpolicy on Cilium-enabled
+      // clusters?
+      prom.NetworkPolicy(instance=promInstance) {
+        metadata+: {
+          namespace: 'openshift-network-diagnostics',
+        },
+      },
+    ],
     '20_metrics_servicemonitors': std.filter(
       function(it) it != null,
       [

--- a/component/metrics.libsonnet
+++ b/component/metrics.libsonnet
@@ -1,16 +1,186 @@
 local kap = import 'lib/kapitan.libjsonnet';
 local kube = import 'lib/kube.libjsonnet';
+local prom = import 'lib/prometheus.libsonnet';
+
 local inv = kap.inventory();
-// The hiera parameters for the component
 local params = inv.parameters.openshift4_networking;
 
 local syn_metrics =
   params.monitoring.enabled &&
   std.member(inv.applications, 'prometheus');
 
+local nsName = 'syn-monitoring-openshift4-networking';
+local promInstance =
+  if params.monitoring.instance != null then
+    params.monitoring.instance
+  else
+    inv.parameters.prometheus.defaultInstance;
+
+local serviceMonitors = [
+  prom.ServiceMonitor('multus-admission-controller') {
+    targetNamespace: 'openshift-multus',
+    selector: {
+      matchLabels: {
+        app: 'multus-admission-controller',
+      },
+    },
+    endpoints: {
+      multus:
+        prom.ServiceMonitorHttpsEndpoint(
+          'multus-admission-controller.openshift-multus.svc'
+        ) {
+          metricRelabelings: [
+            prom.DropRuntimeMetrics,
+          ],
+        },
+    },
+    spec+: {
+      // copied from OCP-managed ServiceMonitor, not sure if this is actually
+      // required.
+      jobLabel: 'app',
+    },
+  },
+  prom.ServiceMonitor('multus-network') {
+    targetNamespace: 'openshift-multus',
+    selector: {
+      matchLabels: {
+        service: 'netowrk-metrics-service',
+      },
+    },
+    endpoints: {
+      network_metrics:
+        prom.ServiceMonitorHttpsEndpoint(
+          'network-metrics-service.openshift-multus.svc',
+        ) {
+          // OCP-managed ServiceMonitor has a 10s interval, but that seems
+          // unnecessary.
+          metricRelabelings: [
+            prom.DropRuntimeMetrics,
+          ],
+        },
+    },
+  },
+  prom.ServiceMonitor('network-check-source') {
+    targetNamespace: 'openshift-network-diagnostics',
+    selector: {
+      matchLabels: {
+        app: 'network-check-source',
+      },
+    },
+    endpoints: {
+      check:
+        prom.ServiceMonitorHttpsEndpoint(
+          'network-check-source.openshift-network-diagnostics.svc'
+        ) {
+          port: 'check-endpoints',
+          tlsConfig+: {
+            // OCP-managed ServiceMonitor also uses insecureSkipVerify
+            insecureSkipVerify: true,
+          },
+          metricRelabelings: [
+            prom.DropRuntimeMetrics,
+            // Drop controller runtime & API server metrics
+            {
+              action: 'drop',
+              regex:
+                '(workqueue_.*|apiserver_.*|rest_client_.*|' +
+                'authenticat(ion|ed)_.*)',
+              sourceLabels: [ '__name__' ],
+            },
+          ],
+        },
+    },
+    spec+: {
+      jobLabel: 'component',
+    },
+  },
+  prom.ServiceMonitor('openshift-sdn') {
+    targetNamespace: 'openshift-sdn',
+    selector: {
+      matchLabels: {
+        app: 'sdn',
+      },
+    },
+    endpoints: {
+      sdn:
+        prom.ServiceMonitorHttpsEndpoint(
+          'sdn.openshift-sdn.svc'
+        ) {
+          metricRelabelings: [
+            prom.DropRuntimeMetrics,
+          ],
+        },
+    },
+    spec+: {
+      jobLabel: 'app',
+    },
+  },
+  prom.ServiceMonitor('ovn-master') {
+    targetNamespace: 'openshift-ovn-kubernetes',
+    selector: {
+      matchLabels: {
+        app: 'ovnkube-master',
+      },
+    },
+    endpoints: {
+      ovn_master:
+        prom.ServiceMonitorHttpsEndpoint(
+          'ovn-kubernetes-master.openshift-ovn-kubernetes.svc'
+        ) {
+          metricRelabelings: [
+            prom.DropRuntimeMetrics,
+          ],
+        },
+    },
+  },
+  prom.ServiceMonitor('ovn-node') {
+    targetNamespace: 'openshift-ovn-kubernetes',
+    selector: {
+      matchLabels: {
+        app: 'ovnkube-node',
+      },
+    },
+    endpoints: {
+      ovn_node_1:
+        prom.ServiceMonitorHttpsEndpoint(
+          'ovn-kubernetes-node.openshift-ovn-kubernetes.svc'
+        ) {
+          metricRelabelings: [
+            prom.DropRuntimeMetrics,
+          ],
+        },
+      ovn_node_2:
+        prom.ServiceMonitorHttpsEndpoint(
+          'ovn-kubernetes-node.openshift-ovn-kubernetes.svc'
+        ) {
+          port: 'ovn-metrics',
+          metricRelabelings: [
+            prom.DropRuntimeMetrics,
+          ],
+        },
+    },
+  },
+];
+
 if syn_metrics then
   {
-    '20_metrics_servicemonitors': [],
+    '20_metrics_namespace': prom.RegisterNamespace(
+      kube.Namespace(nsName),
+      instance=promInstance
+    ),
+    '20_metrics_servicemonitors': std.filter(
+      function(it) it != null,
+      [
+        if params.monitoring.enableServiceMonitors[sm.metadata.name] then
+          sm {
+            metadata+: {
+              name: '%s-%s' % [ sm.targetNamespace, sm.metadata.name ],
+              namespace: nsName,
+            },
+          }
+        for sm in serviceMonitors
+      ]
+    ),
   }
 else
   {

--- a/component/metrics.libsonnet
+++ b/component/metrics.libsonnet
@@ -1,0 +1,17 @@
+local kap = import 'lib/kapitan.libjsonnet';
+local kube = import 'lib/kube.libjsonnet';
+local inv = kap.inventory();
+// The hiera parameters for the component
+local params = inv.parameters.openshift4_networking;
+
+local syn_metrics =
+  params.monitoring.enabled &&
+  std.member(inv.applications, 'prometheus');
+
+if syn_metrics then
+  {
+    '20_metrics_servicemonitors': [],
+  }
+else
+  {
+  }

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -25,6 +25,41 @@ node-role.kubernetes.io/infra: ''
 
 Node selector for the non-DaemonSet OpenShift networking workloads.
 
+== `monitoring`
+
+This parameter allows users to enable the component's monitoring configuration.
+Currently the component has support for deploying custom `ServiceMonitors` on clusters which use component `prometheus` to manage a custom monitoring stack.
+
+The component also deploys a `NetworkPolicy` to allow the independent monitoring stack to access the `openshift-network-diagnostics` metrics.
+
+=== `enabled`
+
+[horizontal]
+type:: boolean
+default:: `true`
+
+Whether to deploy monitoring configurations.
+If this parameter is set to `true`, the component will check whether component `prometheus` is present on the cluster.
+If the component is missing, no configurations will be deployed regardless of the value of this parameter.
+
+=== `instance`
+
+[horizontal]
+type:: string
+default:: `null`
+
+This parameter can be used to indicate which custom Prometheus instance should pick up the configurations managed by the component.
+
+If the parameter is set to `null`, the default instance configured for component `prometheus` will be used.
+
+=== `enableServiceMonitors`
+
+[horizontal]
+type:: dictionary
+default:: https://github.com/appuio/component-openshift4-networking/blob/master/class/defaults.yml[See `class/defaults.yml`]
+
+A dictionary with the names of service monitors as keys and booleans as the value.
+Can be used to selectively enable or disable service monitors.
 
 == `patches`
 

--- a/tests/golden/syn-monitoring/openshift4-networking/openshift4-networking/00_namespace.yaml
+++ b/tests/golden/syn-monitoring/openshift4-networking/openshift4-networking/00_namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations: {}
+  labels:
+    name: openshift-networking
+  name: openshift-networking

--- a/tests/golden/syn-monitoring/openshift4-networking/openshift4-networking/10_node_selector_patch.yaml
+++ b/tests/golden/syn-monitoring/openshift4-networking/openshift4-networking/10_node_selector_patch.yaml
@@ -1,0 +1,93 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    name: ip-reconciler-manager
+  name: ip-reconciler-manager
+  namespace: syn-resource-locker
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    name: syn-resource-locker-ip-reconciler-manager
+  name: syn-resource-locker-ip-reconciler-manager
+rules:
+  - apiGroups:
+      - batch
+    resources:
+      - cronjobs
+    verbs:
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    name: syn-resource-locker-ip-reconciler-manager
+  name: syn-resource-locker-ip-reconciler-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: syn-resource-locker-ip-reconciler-manager
+subjects:
+  - kind: ServiceAccount
+    name: ip-reconciler-manager
+    namespace: syn-resource-locker
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    name: syn-resource-locker-ip-reconciler-manager
+  name: syn-resource-locker-ip-reconciler-manager
+  namespace: openshift-multus
+rules:
+  - apiGroups:
+      - batch
+    resources:
+      - cronjobs
+    verbs:
+      - get
+      - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    name: syn-resource-locker-ip-reconciler-manager
+  name: syn-resource-locker-ip-reconciler-manager
+  namespace: openshift-multus
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: syn-resource-locker-ip-reconciler-manager
+subjects:
+  - kind: ServiceAccount
+    name: ip-reconciler-manager
+    namespace: syn-resource-locker
+---
+apiVersion: redhatcop.redhat.io/v1alpha1
+kind: ResourceLocker
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+  labels:
+    name: openshift-multus-ip-reconciler
+  name: openshift-multus-ip-reconciler
+  namespace: syn-resource-locker
+spec:
+  patches:
+    - id: patch1
+      patchTemplate: "\"spec\":\n  \"jobTemplate\":\n    \"spec\":\n      \"template\"\
+        :\n        \"spec\":\n          \"nodeSelector\":\n            \"node-role.kubernetes.io/infra\"\
+        : \"\""
+      patchType: application/strategic-merge-patch+json
+      targetObjectRef:
+        apiVersion: batch/v1
+        kind: CronJob
+        name: ip-reconciler
+        namespace: openshift-multus
+  serviceAccountRef:
+    name: ip-reconciler-manager

--- a/tests/golden/syn-monitoring/openshift4-networking/openshift4-networking/20_metrics_namespace.yaml
+++ b/tests/golden/syn-monitoring/openshift4-networking/openshift4-networking/20_metrics_namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations: {}
+  labels:
+    monitoring.syn.tools/monitoring: 'true'
+    name: syn-monitoring-openshift4-networking
+  name: syn-monitoring-openshift4-networking

--- a/tests/golden/syn-monitoring/openshift4-networking/openshift4-networking/20_metrics_networkpolicy.yaml
+++ b/tests/golden/syn-monitoring/openshift4-networking/openshift4-networking/20_metrics_networkpolicy.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  annotations: {}
+  labels:
+    name: allow-from-prometheus-monitoring
+  name: allow-from-prometheus-monitoring
+  namespace: openshift-network-diagnostics
+spec:
+  egress: []
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: syn-monitoring
+  podSelector: {}
+  policyTypes:
+    - Ingress

--- a/tests/golden/syn-monitoring/openshift4-networking/openshift4-networking/20_metrics_servicemonitors.yaml
+++ b/tests/golden/syn-monitoring/openshift4-networking/openshift4-networking/20_metrics_servicemonitors.yaml
@@ -1,0 +1,193 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  annotations: {}
+  labels:
+    name: openshift-multus-multus-admission-controller
+  name: openshift-multus-multus-admission-controller
+  namespace: syn-monitoring-openshift4-networking
+spec:
+  endpoints:
+    - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      interval: 30s
+      metricRelabelings:
+        - action: drop
+          regex: (go_.*|process_.*|promhttp_.*)
+          sourceLabels:
+            - __name__
+      port: metrics
+      scheme: https
+      tlsConfig:
+        caFile: /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
+        serverName: multus-admission-controller.openshift-multus.svc
+  jobLabel: app
+  namespaceSelector:
+    matchNames:
+      - openshift-multus
+  selector:
+    matchLabels:
+      app: multus-admission-controller
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  annotations: {}
+  labels:
+    name: openshift-multus-multus-network
+  name: openshift-multus-multus-network
+  namespace: syn-monitoring-openshift4-networking
+spec:
+  endpoints:
+    - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      interval: 30s
+      metricRelabelings:
+        - action: drop
+          regex: (go_.*|process_.*|promhttp_.*)
+          sourceLabels:
+            - __name__
+      port: metrics
+      scheme: https
+      tlsConfig:
+        caFile: /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
+        serverName: network-metrics-service.openshift-multus.svc
+  namespaceSelector:
+    matchNames:
+      - openshift-multus
+  selector:
+    matchLabels:
+      service: netowrk-metrics-service
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  annotations: {}
+  labels:
+    name: openshift-network-diagnostics-network-check-source
+  name: openshift-network-diagnostics-network-check-source
+  namespace: syn-monitoring-openshift4-networking
+spec:
+  endpoints:
+    - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      interval: 30s
+      metricRelabelings:
+        - action: drop
+          regex: (go_.*|process_.*|promhttp_.*)
+          sourceLabels:
+            - __name__
+        - action: drop
+          regex: (workqueue_.*|apiserver_.*|rest_client_.*|authenticat(ion|ed)_.*)
+          sourceLabels:
+            - __name__
+      port: check-endpoints
+      scheme: https
+      tlsConfig:
+        caFile: /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
+        insecureSkipVerify: true
+        serverName: network-check-source.openshift-network-diagnostics.svc
+  jobLabel: component
+  namespaceSelector:
+    matchNames:
+      - openshift-network-diagnostics
+  selector:
+    matchLabels:
+      app: network-check-source
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  annotations: {}
+  labels:
+    name: openshift-sdn-openshift-sdn
+  name: openshift-sdn-openshift-sdn
+  namespace: syn-monitoring-openshift4-networking
+spec:
+  endpoints:
+    - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      interval: 30s
+      metricRelabelings:
+        - action: drop
+          regex: (go_.*|process_.*|promhttp_.*)
+          sourceLabels:
+            - __name__
+      port: metrics
+      scheme: https
+      tlsConfig:
+        caFile: /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
+        serverName: sdn.openshift-sdn.svc
+  jobLabel: app
+  namespaceSelector:
+    matchNames:
+      - openshift-sdn
+  selector:
+    matchLabels:
+      app: sdn
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  annotations: {}
+  labels:
+    name: openshift-ovn-kubernetes-ovn-master
+  name: openshift-ovn-kubernetes-ovn-master
+  namespace: syn-monitoring-openshift4-networking
+spec:
+  endpoints:
+    - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      interval: 30s
+      metricRelabelings:
+        - action: drop
+          regex: (go_.*|process_.*|promhttp_.*)
+          sourceLabels:
+            - __name__
+      port: metrics
+      scheme: https
+      tlsConfig:
+        caFile: /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
+        serverName: ovn-kubernetes-master.openshift-ovn-kubernetes.svc
+  namespaceSelector:
+    matchNames:
+      - openshift-ovn-kubernetes
+  selector:
+    matchLabels:
+      app: ovnkube-master
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  annotations: {}
+  labels:
+    name: openshift-ovn-kubernetes-ovn-node
+  name: openshift-ovn-kubernetes-ovn-node
+  namespace: syn-monitoring-openshift4-networking
+spec:
+  endpoints:
+    - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      interval: 30s
+      metricRelabelings:
+        - action: drop
+          regex: (go_.*|process_.*|promhttp_.*)
+          sourceLabels:
+            - __name__
+      port: metrics
+      scheme: https
+      tlsConfig:
+        caFile: /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
+        serverName: ovn-kubernetes-node.openshift-ovn-kubernetes.svc
+    - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      interval: 30s
+      metricRelabelings:
+        - action: drop
+          regex: (go_.*|process_.*|promhttp_.*)
+          sourceLabels:
+            - __name__
+      port: ovn-metrics
+      scheme: https
+      tlsConfig:
+        caFile: /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
+        serverName: ovn-kubernetes-node.openshift-ovn-kubernetes.svc
+  namespaceSelector:
+    matchNames:
+      - openshift-ovn-kubernetes
+  selector:
+    matchLabels:
+      app: ovnkube-node

--- a/tests/syn-monitoring.yml
+++ b/tests/syn-monitoring.yml
@@ -1,0 +1,28 @@
+applications:
+  - prometheus
+
+parameters:
+  kapitan:
+    dependencies:
+      - type: https
+        source: https://raw.githubusercontent.com/projectsyn/component-resource-locker/v2.1.0/lib/resource-locker.libjsonnet
+        output_path: vendor/lib/resource-locker.libjsonnet
+
+      - type: https
+        source: https://raw.githubusercontent.com/projectsyn/component-prometheus/master/lib/prometheus.libsonnet
+        output_path: vendor/lib/prometheus.libsonnet
+
+  prometheus:
+    defaultInstance: monitoring
+    base: {}
+    instances:
+      monitoring:
+        common:
+          namespace: syn-monitoring
+        prometheus:
+          enabled: true
+
+  resource_locker:
+    namespace: syn-resource-locker
+
+  openshift4_networking: {}


### PR DESCRIPTION
The component always creates `ServiceMonitor` objects for both OVNKubernetes and OpenShift SDN, since the Prometheus service discovery degrades gracefully if no targets are found. This removes the need to add an additional parameter indicating the cluster's network plugin to this component.

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
